### PR TITLE
feat(api)!: add CTFTime API wrapping library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+/.vscode
+/private

--- a/ctftime/client.go
+++ b/ctftime/client.go
@@ -1,0 +1,87 @@
+package ctftime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	UserAgent  string
+	Limiter    *rate.Limiter
+}
+
+func NewClient(baseURL string) *Client {
+	return &Client{
+		BaseURL: baseURL,
+		HTTPClient: &http.Client{
+			Timeout: time.Second * 30,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 100,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		UserAgent: "CTFTimeClient/1.0",
+		Limiter:   rate.NewLimiter(rate.Every(time.Second), 10),
+	}
+}
+
+func (c *Client) request(ctx context.Context, method, path string, body io.Reader, target interface{}) error {
+	if err := c.Limiter.Wait(ctx); err != nil {
+		return fmt.Errorf("rate limit exceeded: %w", err)
+	}
+
+	url := c.BaseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	if target != nil {
+		decoder := json.NewDecoder(resp.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(target); err != nil {
+			return fmt.Errorf("error decoding response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) Get(ctx context.Context, path string, target interface{}) error {
+	return c.request(ctx, http.MethodGet, path, nil, target)
+}
+
+func (c *Client) Post(ctx context.Context, path string, body io.Reader, target interface{}) error {
+	return c.request(ctx, http.MethodPost, path, body, target)
+}
+
+func (c *Client) Put(ctx context.Context, path string, body io.Reader, target interface{}) error {
+	return c.request(ctx, http.MethodPut, path, body, target)
+}
+
+func (c *Client) Delete(ctx context.Context, path string, target interface{}) error {
+	return c.request(ctx, http.MethodDelete, path, nil, target)
+}

--- a/ctftime/events.go
+++ b/ctftime/events.go
@@ -1,0 +1,96 @@
+package ctftime
+
+import (
+	"context"
+	"fmt"
+)
+
+type Organizer struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type CTFDuration struct {
+	Hours int `json:"hours"`
+	Day   int `json:"day"`
+}
+
+type CTFEvent struct {
+	Organizers    []Organizer `json:"organizers"`
+	OnSite        bool        `json:"onsite"`
+	Finish        string      `json:"finish"`
+	Description   string      `json:"description"`
+	Weight        float64     `json:"weight"`
+	Title         string      `json:"title"`
+	URL           string      `json:"url"`
+	IsVotableNow  bool        `json:"is_votable_now"`
+	Restrictions  string      `json:"restrictions"`
+	Format        string      `json:"format"`
+	Start         string      `json:"start"`
+	Participants  int         `json:"participants"`
+	CTFTimeURL    string      `json:"ctftime_url"`
+	Location      string      `json:"location"`
+	LiveFeed      string      `json:"live_feed"`
+	PublicVotable bool        `json:"public_votable"`
+	Duration      CTFDuration `json:"duration"`
+	Logo          string      `json:"logo"`
+	FormatID      int         `json:"format_id"`
+	ID            int         `json:"id"`
+	CTFID         int         `json:"ctf_id"`
+}
+
+func GetEvents(ctx context.Context, args ...int) ([]CTFEvent, error) {
+	limit := 100
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	var events []CTFEvent
+	err := client.Get(ctx, fmt.Sprintf("/v1/events/?limit=%d", limit), &events)
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func GetEventsByPeriod(ctx context.Context, start int, args ...int) ([]CTFEvent, error) {
+	if start < 0 {
+		return nil, fmt.Errorf("invalid start time")
+	}
+
+	finish, limit := -1, 100
+	if len(args) > 0 {
+		finish = args[0]
+	}
+	if len(args) > 1 {
+		limit = args[1]
+	}
+
+	if finish < start {
+		return nil, fmt.Errorf("invalid finish time")
+	}
+
+	var url string
+	if finish == -1 {
+		url = fmt.Sprintf("/v1/events/?limit=%d&start=%d", start, limit)
+	} else {
+		url = fmt.Sprintf("/v1/events/?limit=%d&start=%d&finish=%d", start, finish, limit)
+	}
+
+	client := NewClient("https://ctftime.org/api")
+	var events []CTFEvent
+	if err := client.Get(ctx, url, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func GetSpecificEvent(ctx context.Context, id int) (*CTFEvent, error) {
+	client := NewClient("https://ctftime.org/api")
+	var event CTFEvent
+	err := client.Get(ctx, fmt.Sprintf("/v1/events/%d/", id), &event)
+	if err != nil {
+		return nil, err
+	}
+	return &event, nil
+}

--- a/ctftime/results.go
+++ b/ctftime/results.go
@@ -1,0 +1,46 @@
+package ctftime
+
+import (
+	"context"
+	"fmt"
+)
+
+type CTFScore struct {
+	TeamID int     `json:"team_id"`
+	Points float64 `json:"points"`
+	Place  int     `json:"place"`
+}
+
+type CTFResult struct {
+	Title  string     `json:"title"`
+	Scores []CTFScore `json:"scores"`
+	Time   int        `json:"time"`
+}
+
+func GetResults(ctx context.Context, args ...int) ([]CTFResult, error) {
+	limit := 10
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	var results []CTFResult
+	err := client.Get(ctx, fmt.Sprintf("/v1/results/?limit=%d", limit), &results)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func GetResultsByYear(ctx context.Context, year int, args ...int) ([]CTFResult, error) {
+	limit := 10
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	var results []CTFResult
+	err := client.Get(ctx, fmt.Sprintf("/v1/results/%d/?limit=%d", year, limit), &results)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/ctftime/teams.go
+++ b/ctftime/teams.go
@@ -1,0 +1,62 @@
+package ctftime
+
+import (
+	"context"
+	"fmt"
+)
+
+type BriefTeam struct {
+	Aliases  []string `json:"aliases"`
+	Country  string   `json:"country"`
+	Academic bool     `json:"academic"`
+	ID       int      `json:"id"`
+	Name     string   `json:"name"`
+}
+
+type TeamsResult struct {
+	Limit  int         `json:"limit"`
+	Result []BriefTeam `json:"result"`
+	Offset int         `json:"offset"`
+}
+
+type TeamRating struct {
+	OrganizerPoints *float64 `json:"organizer_points,omitempty"`
+	RatingPoints    *float64 `json:"rating_points,omitempty"`
+	RatingPlace     *int     `json:"rating_place,omitempty"`
+	CountryPlace    *int     `json:"country_place,omitempty"`
+}
+
+type Team struct {
+	Academic     bool                  `json:"academic"`
+	PrimaryAlias string                `json:"primary_alias"`
+	Name         string                `json:"name"`
+	Rating       map[string]TeamRating `json:"rating"`
+	Logo         string                `json:"logo"`
+	Country      string                `json:"country"`
+	ID           int                   `json:"id"`
+	Aliases      []string              `json:"aliases"`
+}
+
+func GetTeams(ctx context.Context, args ...int) (*TeamsResult, error) {
+	limit := 100
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	var teams TeamsResult
+	err := client.Get(ctx, fmt.Sprintf("/v1/teams/?limit=%d", limit), &teams)
+	if err != nil {
+		return nil, err
+	}
+	return &teams, nil
+}
+
+func GetTeamByID(ctx context.Context, id int) (*Team, error) {
+	client := NewClient("https://ctftime.org/api")
+	var team Team
+	err := client.Get(ctx, fmt.Sprintf("/v1/teams/%d/", id), &team)
+	if err != nil {
+		return nil, err
+	}
+	return &team, nil
+}

--- a/ctftime/top.go
+++ b/ctftime/top.go
@@ -1,0 +1,54 @@
+package ctftime
+
+import (
+	"context"
+	"fmt"
+)
+
+type TopTeam struct {
+	TeamName string  `json:"team_name"`
+	Points   float64 `json:"points"`
+	TeamID   int     `json:"team_id"`
+}
+
+func GetTopTeams(ctx context.Context, args ...int) (map[string][]TopTeam, error) {
+	limit := 10
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	teamsData := make(map[string][]TopTeam)
+	err := client.Get(ctx, fmt.Sprintf("/v1/top/?limit=%d", limit), &teamsData)
+	if err != nil {
+		return nil, err
+	}
+	return teamsData, nil
+}
+
+func GetTopTeamsByYear(ctx context.Context, year int, args ...int) (map[string][]TopTeam, error) {
+	limit := 10
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	teamsData := make(map[string][]TopTeam)
+	err := client.Get(ctx, fmt.Sprintf("/v1/top/%d/?limit=%d", year, limit), &teamsData)
+	if err != nil {
+		return nil, err
+	}
+	return teamsData, nil
+}
+
+func GetTopTeamsByCountry(ctx context.Context, country string, args ...int) (map[string][]TopTeam, error) {
+	limit := 10
+	if len(args) > 0 {
+		limit = args[0]
+	}
+	client := NewClient("https://ctftime.org/api")
+	teamsData := make(map[string][]TopTeam)
+	err := client.Get(ctx, fmt.Sprintf("/v1/top-by-country/%s/?limit=%d", country, limit), &teamsData)
+	if err != nil {
+		return nil, err
+	}
+	return teamsData, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module ctfbot.urdekcah.ru
+
+go 1.22.6
+
+require golang.org/x/time v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
+golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=


### PR DESCRIPTION
Integrated a library to wrap the CTFTime API, enabling streamlined interaction with CTF event data. This library provides a simple interface for retrieving and managing CTFTime information, making it easier to access event details programmatically.

Refs: #1